### PR TITLE
Widget styling

### DIFF
--- a/special-widget.scss
+++ b/special-widget.scss
@@ -1,0 +1,17 @@
+.special-widget {
+	background: grey;
+	row: 1;
+ 
+	& > .content--red {
+		background: red;
+	}
+ 
+	&.special-widget__disabled {
+		opacity: 0.3;
+		pointer-events: none;
+	}
+ 
+	&::hover {
+		border-color: blue;
+	}
+}

--- a/widget.scss
+++ b/widget.scss
@@ -1,0 +1,20 @@
+.widgetContainer {
+	display: grid;
+	grid-template-rows: auto 1fr;
+	grid-template-columns: 100px 100px 100px;
+ 
+	& > .special-widget {
+		border: 1px solid black;
+	}
+}
+
+.widget {
+	margin: 10px;
+	width: 100px;
+	height: 100px;
+	border: 1px solid black
+	
+	& label {
+		height: 20px;
+	}
+}


### PR DESCRIPTION
# What's new/changed?

1. Adds `widget` styling
2. Adds `special-widget` styling that extends `widgets`

<img width="206" alt="widget" src="https://user-images.githubusercontent.com/1615460/65425450-ea61ee00-de05-11e9-9842-fda80cc3d6ed.png">
